### PR TITLE
Fix b tree iter

### DIFF
--- a/PyThermite/src/index/core/query/b_tree/nodes/leaf_node.rs
+++ b/PyThermite/src/index/core/query/b_tree/nodes/leaf_node.rs
@@ -223,7 +223,7 @@ impl<'a> Iterator for LeafNodeIter<'a> {
         if self.idx >= self.leaf.num_keys {
             return None;
         }
-        let ck = self.leaf.keys[self.leaf.offset..self.leaf.offset + self.leaf.num_keys][self.idx];
+        let ck = self.leaf.keys[self.leaf.offset + self.idx];
         self.idx += 1;
 
         Some(ck)

--- a/PyThermite/src/index/core/query/query.rs
+++ b/PyThermite/src/index/core/query/query.rs
@@ -291,30 +291,30 @@ impl QueryMap {
                 let iter_guard = &self.read_num_ordered();
                 let bitmap_iter = BitMapBTreeIter::new(iter_guard);
 
-                let mut current_val: Option<u128> = None;
+                let mut current_val: Option<CompositeKey128> = None;
                 let mut current_bitmap: Bitmap = Bitmap::new();
 
                 for composite_key in bitmap_iter {
                     let id = composite_key.get_id();
-                    let key_val = composite_key.get_value_bits();
 
-                    if Some(key_val) != current_val {
-                        // push previous group if exists
-                        if let Some(cv) = current_val {
-                            let pyval = PyValue::from_primitave(RustCastValue::Float(CompositeKey128::decode_float(cv)));
+                    if let Some(prev_ck) = current_val {
+                        if prev_ck.get_value_bits() != composite_key.get_value_bits() {
+                            // Flush previous group
+                            let pyval = PyValue::from_primitave(RustCastValue::Float(prev_ck.decode_float()));
                             let hset = HybridSet::Large(current_bitmap.clone());
                             res.push((pyval, hset));
                             current_bitmap.clear();
                         }
-                        current_val = Some(key_val);
                     }
 
+                    // Update current value and accumulate IDs
+                    current_val = Some(composite_key);
                     current_bitmap.add(id);
                 }
 
                 // push last group
                 if let Some(cv) = current_val {
-                    let pyval = PyValue::from_primitave(RustCastValue::Float(CompositeKey128::decode_float(cv)));
+                    let pyval = PyValue::from_primitave(RustCastValue::Float(cv.decode_float()));
                     let hset = HybridSet::Large(current_bitmap);
                     res.push((pyval, hset));
                 }

--- a/tests/test_group_by.py
+++ b/tests/test_group_by.py
@@ -91,7 +91,7 @@ def test_group_by_many_to_many(index: Index):
         assert ind.nested[0].idx == 100
 
 def test_group_by_one_to_many_deregister(index: Index):
-    nested = TestClass(nest=True)
+    nested = TestClass(nest=True, num = 100)
     for i in range(10):
         index.add_object(TestClass(id=i, nested=nested))
 
@@ -105,6 +105,10 @@ def test_group_by_one_to_many_deregister(index: Index):
     grouped = index.group_by("nested.nest")
 
     all = grouped[True].collect()
+    assert len(all) == 9
+
+    grouped = index.group_by("nested.num")
+    all = grouped[100].collect()
     assert len(all) == 9
 
 def test_remove_and_reassign_tracked_list(index: Index):
@@ -135,3 +139,16 @@ def test_remove_and_reassign_tracked_list(index: Index):
     grouped_after_mutation = index.group_by("nested.num")
     first_group = grouped_after_mutation[999].collect()
     assert all(o.nested[0].num == 999 for o in first_group)
+
+def test_nested_group_by_many_to_many(index: Index):
+    children = [TestClass(num=i) for i in range(1000)]
+
+    for c in children:
+        c.child = [TestClass(nested_num=i) for i in range(3)]
+
+    index.add_object_many(children)
+
+    groups = index.group_by("child.nested_num")
+
+    for i in range(3):
+        assert len(groups[i].collect()) == 1000, f"{i} has invalid length"


### PR DESCRIPTION
Fixes an error when group_by is performed on numeric fields caused by a bad iterator